### PR TITLE
Update curl-to-php.js

### DIFF
--- a/resources/js/curl-to-php.js
+++ b/resources/js/curl-to-php.js
@@ -125,6 +125,8 @@ function curlToPHP(curl) {
 
 			// render PHP code to put all the data in the body, concatenating if necessary
 			if (ioReaders.length == 1 && typeof varName == 'undefined') {
+				//If variable have code ".. -d attributes='{...", delete quotes.
+                                ioReaders[0] = ioReaders[0].replace(/\=[\'\"]\{([^$]+)\}[\'\"]/, '={$1}');
 				php += 'curl_setopt($ch, CURLOPT_POSTFIELDS, '+ioReaders[0]+');\n';
 			} else if (ioReaders.length > 0) {
 				php += '$post = array(\n    ';


### PR DESCRIPTION
If, we have console curl:
-d type_name=xxx -d attributes='{"name":"test"}'
we get convert value
curl_setopt($ch, CURLOPT_POSTFIELDS, "type_name=xxx&attributes='{"name":"test"}'");
It is bug. Right convert:
curl_setopt($ch, CURLOPT_POSTFIELDS, "type_name=xxx&attributes={"name":"test"}");