### PR TITLE
Content-Type header field name case insensitivity

### DIFF
--- a/resources/js/curl-to-php.js
+++ b/resources/js/curl-to-php.js
@@ -217,7 +217,7 @@ function curlToPHP(curl) {
 			// curl adds a default Content-Type header if not set explicitly
 			var hasContentType = false;
 			for (var i = 0; i < relevant.headers.length; i++) {
-				if (relevant.headers[i].indexOf("Content-Type") == 0) {
+				if (toTitleCase(relevant.headers[i]).indexOf("Content-Type") == 0) {
 					hasContentType = true;
 					break;
 				}


### PR DESCRIPTION
Currently, the Content-Type header is ignored and discarded if the capitalization of the field name is not exactly "Content-Type".
This commit fixes the behaviour according to the RFC spec which says that header field names are case insensitive: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2