### PR TITLE
Support -F and --form option

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,9 @@
 			<h2>Instantly convert <a href="http://curl.haxx.se/">curl</a> commands to <a href="http://php.net/">PHP</a> code</h2>
 
 			<p>
-				This tool turns a Curl command into PHP code. Currently, it knows the following options: -d/--data/--data-binary, -H/--header, -I/--head, -u/--user, compressed, ---url and -X/--request. There's probably bugs; please <a href="https://github.com/incarnate/curl-to-php">contribute on GitHub</a>!
+				This tool turns a Curl command into PHP code. Currently, it knows the following options: -d/--data/--data-binary, -F/--form, -H/--header, -I/--head, -u/--user, compressed, ---url and -X/--request. There's probably bugs; please <a href="https://github.com/incarnate/curl-to-php">contribute on GitHub</a>!
 			</p>
-			
+
 			<p>
 				This script derives from Matt Holt's excellent <a href="https://github.com/mholt/curl-to-go">curl-to-Go</a>.
 			</p>


### PR DESCRIPTION
This PR allow to convert curl to php with options `-F` and `--form`.
Example:

```bash
curl -X POST https://api.easypost.com/v2/shipments \
     -u API_KEY: \
     -F 'field[0]=value1' \
     -F 'field[1]=@myFile.png'
```
is converted as
```php
$ch = curl_init();

curl_setopt($ch, CURLOPT_URL, 'https://api.easypost.com/v2/shipments');
curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
curl_setopt($ch, CURLOPT_POST, 1);
$post = array(
    'field[0]' => 'value1',
    'field[1]' => '@' .realpath('myFile.png')
);
curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
curl_setopt($ch, CURLOPT_USERPWD, 'API_KEY' . ':' . '');

$result = curl_exec($ch);
if (curl_errno($ch)) {
    echo 'Error:' . curl_error($ch);
}
curl_close($ch);

```
If this PR is merged, issue #26 can be closed