### PR TITLE
Always set method to POST when data-raw flag is present

### DIFF
--- a/resources/js/curl-to-php.js
+++ b/resources/js/curl-to-php.js
@@ -261,8 +261,10 @@ function curlToPHP(curl) {
 			loadData(cmd.d);
 		if (cmd.data)
 			loadData(cmd.data);
-		if (cmd['data-raw'])
+		if (cmd['data-raw']) {
 			loadData(cmd['data-raw']);
+			relevant.method = 'POST';
+		}
 		if (cmd['data-binary'])
 			loadData(cmd['data-binary']);
 		if (cmd.F)


### PR DESCRIPTION
Per [the cURL manual](https://curl.se/docs/manpage.html#--data-raw) the `--data-raw` flag POSTs data